### PR TITLE
feat(export): add 9:16 portrait option to image export sizes

### DIFF
--- a/components/dialogs/ExportDialog.tsx
+++ b/components/dialogs/ExportDialog.tsx
@@ -47,6 +47,7 @@ const SIZES = [
   { label: "Full HD", w: 1920, h: 1080 },
   { label: "4K", w: 3840, h: 2160 },
   { label: "Square 2048", w: 2048, h: 2048 },
+  { label: "Portrait", w: 2160, h: 3840 }
 ];
 
 const DURATIONS = [


### PR DESCRIPTION
## Summary

This PR adds a new 9:16 `Portrait` (2160×3840) preset to the `SIZES` array in the Image Export dialog. 

**Why?** The default quick-select buttons only covered landscape and square aspect ratios. With mobile displays being the dominant format for UI backgrounds, TikToks, and Reels, users had to manually type in vertical dimensions every time they wanted to export. This addition removes that friction and speeds up the mobile design workflow.

## Type of change

- [x] Feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Performance (`perf`)
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] Verified the change in the running app
- [x] Self-reviewed the diff

## Screenshots / recordings

*(I have attached the before and after screenshots of the Export Dialog below)*

## BEFORE
<img width="655" height="522" alt="Screenshot 2026-07-13 233751" src="https://github.com/user-attachments/assets/39f2b878-c056-4c69-841c-a913938b55b7" />

## AFTER
<img width="657" height="538" alt="Screenshot 2026-07-13 233829" src="https://github.com/user-attachments/assets/c988ac07-f9a1-4d00-aeac-847f5799aae9" />




