### PR TITLE
Feature/portrait export

### DIFF
--- a/components/dialogs/ExportDialog.tsx
+++ b/components/dialogs/ExportDialog.tsx
@@ -47,6 +47,7 @@ const SIZES = [
   { label: "Full HD", w: 1920, h: 1080 },
   { label: "4K", w: 3840, h: 2160 },
   { label: "Square 2048", w: 2048, h: 2048 },
+  { label: "Portrait", w: 2160, h: 3840 }
 ];
 
 const DURATIONS = [

--- a/components/dialogs/ExportDialog.tsx
+++ b/components/dialogs/ExportDialog.tsx
@@ -47,7 +47,7 @@ const SIZES = [
   { label: "Full HD", w: 1920, h: 1080 },
   { label: "4K", w: 3840, h: 2160 },
   { label: "Square 2048", w: 2048, h: 2048 },
-  { label: "Portrait", w: 2160, h: 3840 }
+  { label: "Portrait 4k", w: 2160, h: 3840 }
 ];
 
 const DURATIONS = [


### PR DESCRIPTION
## Summary

This PR adds a new 9:16 Portrait 4k (2160×3840) preset to the SIZES array in the Image Export dialog.

Why? The default quick-select buttons only covered landscape and square aspect ratios. With mobile displays being the dominant format for UI backgrounds, TikToks, and Reels, users had to manually type in vertical dimensions every time they wanted to export. This addition removes that friction and speeds up the mobile design workflow.

## Type of change

- [x] Feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Performance (`perf`)
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] Verified the change in the running app
- [x] Self-reviewed the diff

## Screenshots / recordings

## BEFORE
<img width="655" height="522" alt="Screenshot 2026-07-13 233751" src="https://github.com/user-attachments/assets/cba90fd0-281c-425b-9843-ea1b367a608c" />

##  AFTER
<img width="656" height="523" alt="Screenshot 2026-07-14 180106" src="https://github.com/user-attachments/assets/8fdb240a-e292-4521-b750-9f60c6ec6209" />


