### PR TITLE
feat(presets,ui): add saveable custom preset library

### DIFF
--- a/components/panels/PresetsRail.tsx
+++ b/components/panels/PresetsRail.tsx
@@ -6,12 +6,19 @@
  * no extra WebGL contexts) after mount.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { PRESETS, PRESET_CATEGORIES } from "@/lib/presets";
 import { renderThumbnail } from "@/lib/mesh";
 import { useMeshStore } from "@/store/meshStore";
 import { useUiStore } from "@/store/uiStore";
+import {
+  loadUserPresets,
+  saveUserPreset,
+  deleteUserPreset,
+  type UserPreset,
+} from "@/lib/userPresets";
+import { PlusIcon, TrashIcon, CheckIcon } from "@/components/ui/icons";
 import type { PresetCategory } from "@/types/gradient";
 import { cn, isCompact } from "@/lib/utils";
 
@@ -27,13 +34,40 @@ export function PresetsRail() {
   };
   const [category, setCategory] = useState<PresetCategory | "All">("All");
   const [thumbs, setThumbs] = useState<Record<string, string>>({});
+  const [userPresets, setUserPresets] = useState<UserPreset[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [name, setName] = useState("");
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  // Read the saved library after mount (localStorage is client-only).
+  useEffect(() => {
+    setUserPresets(loadUserPresets());
+  }, [open]);
 
   useEffect(() => {
     // Rasterize lazily after mount so SSR/hydration stay clean.
     const t: Record<string, string> = {};
     for (const p of PRESETS) t[p.id] = renderThumbnail(p.doc, 128, 96);
+    for (const p of userPresets) t[p.id] = renderThumbnail(p.doc, 128, 96);
     setThumbs(t);
-  }, []);
+  }, [userPresets]);
+
+  const beginSave = () => {
+    setName("");
+    setSaving(true);
+    requestAnimationFrame(() => nameRef.current?.focus());
+  };
+  const commitSave = () => {
+    const doc = useMeshStore.getState().doc;
+    saveUserPreset(doc, name || "Untitled");
+    setUserPresets(loadUserPresets());
+    setSaving(false);
+  };
+  const removePreset = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    deleteUserPreset(id);
+    setUserPresets(loadUserPresets());
+  };
 
   const visible =
     category === "All" ? PRESETS : PRESETS.filter((p) => p.category === category);
@@ -50,11 +84,105 @@ export function PresetsRail() {
           aria-label="Preset browser"
         >
           <div className="flex h-full w-[min(82vw,15rem)] flex-col lg:w-60">
-            <header className="border-b border-glass-border px-4 py-2.5">
+            <header className="flex items-center justify-between gap-2 border-b border-glass-border px-4 py-2.5">
               <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted">
                 Presets
               </h2>
+              {saving ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    ref={nameRef}
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitSave();
+                      if (e.key === "Escape") setSaving(false);
+                    }}
+                    placeholder="Name…"
+                    aria-label="Preset name"
+                    className="h-7 w-24 rounded-md border border-glass-border bg-glass-soft px-2 text-[12px] text-ink outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                  />
+                  <button
+                    type="button"
+                    onClick={commitSave}
+                    aria-label="Save preset"
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-hover hover:text-ink focus-visible:ring-2 focus-visible:ring-focus"
+                  >
+                    <CheckIcon />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSaving(false)}
+                    aria-label="Cancel"
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-hover hover:text-ink focus-visible:ring-2 focus-visible:ring-focus"
+                  >
+                    <TrashIcon />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={beginSave}
+                  aria-label="Save current design as preset"
+                  title="Save preset"
+                  className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium text-faint outline-none transition-colors hover:bg-hover hover:text-ink focus-visible:ring-2 focus-visible:ring-focus"
+                >
+                  <PlusIcon className="h-3.5 w-3.5" />
+                  Save
+                </button>
+              )}
             </header>
+
+            {/* User's own saved designs — pinned above the curated library. */}
+            {userPresets.length > 0 && (
+              <div className="studio-scroll border-b border-glass-border p-3 pb-2">
+                <p className="mb-2 px-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">
+                  Your presets
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {userPresets.map((preset, i) => (
+                    <motion.button
+                      key={preset.id}
+                      type="button"
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.25 }}
+                      whileHover={{ y: -2, scale: 1.03 }}
+                      whileTap={{ scale: 0.96 }}
+                      onClick={() => applyPreset(preset.doc)}
+                      className={cn(
+                        "group relative h-20 cursor-pointer overflow-hidden rounded-lg border border-glass-border shadow-sm outline-none transition-shadow hover:shadow-lift",
+                        "focus-visible:ring-2 focus-visible:ring-focus"
+                      )}
+                      aria-label={`Apply your preset ${preset.name}`}
+                      title={preset.name}
+                    >
+                      {thumbs[preset.id] ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={thumbs[preset.id]}
+                          alt=""
+                          className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+                        />
+                      ) : (
+                        <span className="absolute inset-0 animate-pulse bg-glass-soft" />
+                      )}
+                      <span className="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/55 to-transparent px-2 pb-1 pt-3 text-left text-[10px] font-medium text-white opacity-0 transition-opacity group-hover:opacity-100">
+                        {preset.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={(e) => removePreset(e, preset.id)}
+                        aria-label={`Delete preset ${preset.name}`}
+                        className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/45 text-white opacity-0 outline-none transition-opacity hover:bg-black/70 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-focus group-hover:opacity-100"
+                      >
+                        <TrashIcon className="h-3 w-3" />
+                      </button>
+                    </motion.button>
+                  ))}
+                </div>
+              </div>
+            )}
 
             <div className="studio-scroll flex shrink-0 gap-1 overflow-x-auto border-b border-glass-border px-3 py-2">
               {(["All", ...PRESET_CATEGORIES] as const).map((c) => (

--- a/components/panels/PresetsRail.tsx
+++ b/components/panels/PresetsRail.tsx
@@ -63,7 +63,10 @@ export function PresetsRail() {
     setUserPresets(loadUserPresets());
     setSaving(false);
   };
-  const removePreset = (e: React.MouseEvent, id: string) => {
+  const removePreset = (
+    e: React.MouseEvent | React.KeyboardEvent,
+    id: string
+  ) => {
     e.stopPropagation();
     deleteUserPreset(id);
     setUserPresets(loadUserPresets());
@@ -141,15 +144,22 @@ export function PresetsRail() {
                 </p>
                 <div className="grid grid-cols-2 gap-2">
                   {userPresets.map((preset, i) => (
-                    <motion.button
+                    <motion.div
                       key={preset.id}
-                      type="button"
+                      role="button"
+                      tabIndex={0}
                       initial={{ opacity: 0, y: 10 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.25 }}
                       whileHover={{ y: -2, scale: 1.03 }}
                       whileTap={{ scale: 0.96 }}
                       onClick={() => applyPreset(preset.doc)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          applyPreset(preset.doc);
+                        }
+                      }}
                       className={cn(
                         "group relative h-20 cursor-pointer overflow-hidden rounded-lg border border-glass-border shadow-sm outline-none transition-shadow hover:shadow-lift",
                         "focus-visible:ring-2 focus-visible:ring-focus"
@@ -170,15 +180,23 @@ export function PresetsRail() {
                       <span className="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/55 to-transparent px-2 pb-1 pt-3 text-left text-[10px] font-medium text-white opacity-0 transition-opacity group-hover:opacity-100">
                         {preset.name}
                       </span>
-                      <button
-                        type="button"
+                      <div
+                        role="button"
+                        tabIndex={0}
                         onClick={(e) => removePreset(e, preset.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            removePreset(e, preset.id);
+                          }
+                        }}
                         aria-label={`Delete preset ${preset.name}`}
                         className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/45 text-white opacity-0 outline-none transition-opacity hover:bg-black/70 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-focus group-hover:opacity-100"
                       >
                         <TrashIcon className="h-3 w-3" />
-                      </button>
-                    </motion.button>
+                      </div>
+                    </motion.div>
                   ))}
                 </div>
               </div>

--- a/lib/userPresets.ts
+++ b/lib/userPresets.ts
@@ -1,0 +1,73 @@
+/**
+ * User preset library — the user's own saved designs, persisted locally.
+ *
+ * Saved designs round-trip through the same serializable `MeshDoc` the
+ * built-in presets use, so applying one is just `applyDoc(doc)`. Storage is
+ * `localStorage` (the same place the theme lives); every access is guarded so
+ * SSR and private-mode browsers degrade to an empty library instead of throwing.
+ */
+
+import type { MeshDoc } from "@/types/gradient";
+
+const STORAGE_KEY = "zoxilsi-presets";
+const MAX_PRESETS = 50;
+
+export interface UserPreset {
+  id: string;
+  name: string;
+  doc: MeshDoc;
+  createdAt: number;
+}
+
+function safeParse(raw: string | null): UserPreset[] {
+  if (!raw) return [];
+  try {
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data.filter(
+      (p): p is UserPreset => !!p && typeof p.id === "string" && !!p.doc
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Read the saved library. Empty (never throws) when storage is unavailable. */
+export function loadUserPresets(): UserPreset[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return safeParse(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return [];
+  }
+}
+
+function persist(presets: UserPreset[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // Quota or privacy mode — the in-memory list still works this session.
+  }
+}
+
+/**
+ * Snapshot `doc` into the library under `name`. Clones the doc so later edits
+ * never mutate a saved preset. Newest first; capped so storage stays bounded.
+ */
+export function saveUserPreset(doc: MeshDoc, name: string): UserPreset {
+  const preset: UserPreset = {
+    id: `u${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`,
+    name: name.trim() || "Untitled",
+    doc: structuredClone(doc),
+    createdAt: Date.now(),
+  };
+  const next = [preset, ...loadUserPresets()].slice(0, MAX_PRESETS);
+  persist(next);
+  return preset;
+}
+
+/** Remove a saved preset by id. No-op if it isn't there. */
+export function deleteUserPreset(id: string): void {
+  persist(loadUserPresets().filter((p) => p.id !== id));
+}


### PR DESCRIPTION
Let users snapshot the current design into a local preset library persisted in localStorage, shown as a 'Your presets' group above the curated library and re-loadable like any built-in preset.

- lib/userPresets.ts: SSR-safe localStorage helpers (load/save/delete, cloned docs, 50-preset cap, matches the theme storage pattern)
- PresetsRail.tsx: Save button + inline name input, user-preset grid with per-tile delete, wired through applyDoc (single undo step)

Verified with tsc --noEmit, eslint (0 errors) and pnpm build.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Performance (`perf`)
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [ ] `pnpm exec tsc --noEmit` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm build` succeeds
- [ ] Verified the change in the running app
- [ ] Self-reviewed the diff

## Screenshots 

<img width="331" height="242" alt="image" src="https://github.com/user-attachments/assets/05b3fbb3-d980-4d05-acb6-ea78bf266933" />


## Before
<img width="981" height="317" alt="image" src="https://github.com/user-attachments/assets/5a257a9e-11a6-431a-84ac-5fa5bba45c9a" />


### After refresh 
<img width="751" height="355" alt="image" src="https://github.com/user-attachments/assets/42c8430f-2acd-4a24-bca4-92a994e0642a" />


<!-- For any visual change, attach a before/after. -->
